### PR TITLE
Fix issues that cause runtime errors on Mac and Ubuntu

### DIFF
--- a/lib/ctrlemulator.py
+++ b/lib/ctrlemulator.py
@@ -53,7 +53,7 @@ class OZWSerialEmul:
         self._cbTimeOut = cbTimeOut
         self._lockWrite = threading.Lock()  # use to lock write data on serial when waiting for an ACK
         self._log.write(LogLevel.Info, "  Opening emulate controller {0}".format(port))
-        self._serial = serial.Serial(port,  baud, timeout = timeout)
+        self._serial = serial.Serial(port,  baud, timeout = timeout, rtscts=True, dsrdtr=True)
         self._readMsg = threading.Thread(None, self.waitData, "th_Handle_Read_Msg", (), {})
         self._readMsg.start()
         

--- a/lib/xmlfiles.py
+++ b/lib/xmlfiles.py
@@ -474,7 +474,7 @@ class DeviceClasses:
 #        import pprint
 
         """Read XML device_classes.xml of open-zwave C++ lib"""
-        self.xml_file = path + "\device_classes.xml"
+        self.xml_file = path + "/device_classes.xml"
 
         self.xml_content = minidom.parse(self.xml_file)
         # read xml file


### PR DESCRIPTION
- the slash needs to be different for Mac & Ubuntu
- the new pyserial requires two additional parameters
